### PR TITLE
feat: add multi-platform Docker image support via GoReleaser

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -26,7 +26,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: v2.4.8
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - go mod tidy
@@ -46,7 +48,7 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 # Publish to GitHub
 release:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,6 +34,40 @@ archives:
       - goos: windows
         format: binary
 
+dockers:
+  - image_templates:
+      - "ghcr.io/felipeneuwald/stressy:{{ .Version }}-amd64"
+      - "ghcr.io/felipeneuwald/stressy:latest-amd64"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+    dockerfile: Dockerfile
+    extra_files:
+      - LICENSE
+    goos: linux
+    goarch: amd64
+  - image_templates:
+      - "ghcr.io/felipeneuwald/stressy:{{ .Version }}-arm64"
+      - "ghcr.io/felipeneuwald/stressy:latest-arm64"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+    dockerfile: Dockerfile
+    extra_files:
+      - LICENSE
+    goos: linux
+    goarch: arm64
+
+docker_manifests:
+  - name_template: ghcr.io/felipeneuwald/stressy:{{ .Version }}
+    image_templates:
+      - ghcr.io/felipeneuwald/stressy:{{ .Version }}-amd64
+      - ghcr.io/felipeneuwald/stressy:{{ .Version }}-arm64
+  - name_template: ghcr.io/felipeneuwald/stressy:latest
+    image_templates:
+      - ghcr.io/felipeneuwald/stressy:latest-amd64
+      - ghcr.io/felipeneuwald/stressy:latest-arm64
+
 changelog:
   sort: asc
   filters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
-FROM alpine:latest
+FROM alpine:3.19
 
-COPY bin/stressy_linux /
+LABEL org.opencontainers.image.source="https://github.com/felipeneuwald/stressy"
+LABEL org.opencontainers.image.description="A simple stress test tool"
+LABEL org.opencontainers.image.licenses="MIT"
+
+COPY stressy /usr/local/bin/
+RUN chmod +x /usr/local/bin/stressy
+
+ENTRYPOINT ["/usr/local/bin/stressy"]


### PR DESCRIPTION
This PR adds support for building and publishing multi-platform Docker images using GoReleaser and Docker buildx.

### Changes
- Updated Dockerfile:
  - Use Alpine 3.19 as base image
  - Added OpenContainers labels for better metadata
  - Improved binary placement and permissions

- Added Docker support to GoReleaser:
  - Multi-platform builds (amd64, arm64)
  - Uses Docker buildx for efficient cross-platform builds
  - Publishes to GitHub Container Registry (ghcr.io)
  - Creates platform-specific tags and multi-arch manifests
  - Maintains both versioned and latest tags

### Docker Images
Images will be available at:
- `ghcr.io/felipeneuwald/stressy:latest` (multi-arch)
- `ghcr.io/felipeneuwald/stressy:v2.1.0` (multi-arch)
- Platform-specific tags also available (e.g., `:v2.1.0-amd64`, `:v2.1.0-arm64`)

### Platforms Supported
- linux/amd64
- linux/arm64